### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that allows running Claude Code in one-shot mode with permissions bypassed automatically.
 
+<a href="https://glama.ai/mcp/servers/@steipete/claude-code-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@steipete/claude-code-mcp/badge" alt="Claude Code Server MCP server" />
+</a>
+
 ## Overview
 
 This MCP server provides two tools that can be used by LLMs to interact with Claude Code. When integrated with Claude Desktop or other MCP clients, it allows LLMs to:


### PR DESCRIPTION
This PR adds a badge for the [Claude Code MCP Server](https://glama.ai/mcp/servers/@steipete/claude-code-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@steipete/claude-code-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@steipete/claude-code-mcp/badge" alt="Claude Code Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.