### PR TITLE
Feat: Increase execution timeout to 30 minutes (v1.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2025-05-14
+
+### Changed
+- Increased the maximum execution timeout for the Claude Code tool from 5 minutes to 30 minutes.
+
 ## [1.9.0] - 2025-05-14
 
 ### Changed

--- a/dist/server.js
+++ b/dist/server.js
@@ -163,7 +163,7 @@ class ClaudeCodeServer {
             ],
         }));
         // Handle tool calls
-        const executionTimeoutMs = 300000; // 5 minutes timeout
+        const executionTimeoutMs = 1800000; // 30 minutes timeout
         this.server.setRequestHandler(CallToolRequestSchema, async (args, call) => {
             debugLog('[Debug] Handling CallToolRequest:', args);
             // Correctly access toolName from args.params.name

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/claude-code-mcp",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Simple MCP server for Claude Code one-shot execution",
   "author": "Peter Steinberger",
   "license": "MIT",

--- a/src/server.ts
+++ b/src/server.ts
@@ -198,7 +198,7 @@ class ClaudeCodeServer {
     }));
 
     // Handle tool calls
-    const executionTimeoutMs = 300000; // 5 minutes timeout
+    const executionTimeoutMs = 1800000; // 30 minutes timeout
 
     this.server.setRequestHandler(CallToolRequestSchema, async (args, call): Promise<ServerResult> => {
       debugLog('[Debug] Handling CallToolRequest:', args);


### PR DESCRIPTION
Feat: Increase Claude Code tool execution timeout to 30 minutes. Bumps version to 1.9.1.