### PR TITLE
Docs: Add GitHub Actions workflow fix example for v1.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.5] - 2025-05-15
+
+### Added
+- Added a new visual example (`github_actions_fix_example.png`) to `README.md` showcasing precise GitHub Actions workflow file correction.
+
 ## [1.9.4] - 2025-05-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ Here's an example of the Claude Code tool listing files in a directory:
 
 <img src="assets/file_list_example.png" alt="File listing example" width="50%">
 
+### GitHub Actions Workflow Fix Example
+
+Claude Code can help you make precise corrections to GitHub Actions workflow files:
+
+<img src="assets/github_actions_fix_example.png" alt="GitHub Actions fix example" width="50%">
+
 ## Key Use Cases
 
 This server, through its unified `claude_code` tool, unlocks a wide range of powerful capabilities by giving your AI direct access to the Claude Code CLI. Here are some examples of what you can achieve:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/claude-code-mcp",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Simple MCP server for Claude Code one-shot execution",
   "author": "Peter Steinberger",
   "license": "MIT",


### PR DESCRIPTION
This PR adds a new visual example to the `README.md` demonstrating how `claude_code` can be used to make precise corrections to GitHub Actions workflow files.