### PR TITLE
Add tool version and startup time print on first use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.10.1] - 2025-05-17
 
-### Added
 - Tool version and startup time print on first use
 
 ## [1.10.0] - 2025-05-17
 
-### Added
 - Support for `CLAUDE_CLI_NAME` environment variable to override the Claude CLI binary name
 - Support for absolute paths in `CLAUDE_CLI_NAME` (e.g., `/tmp/claude-test`)
 - Comprehensive unit and e2e tests for the server functionality
 - Test infrastructure with mocked Claude CLI for reliable testing
-
-### Changed
 - `CLAUDE_CLI_NAME` now supports both simple names and absolute paths
 - Relative paths in `CLAUDE_CLI_NAME` now throw an error (security improvement)
 - Removed test mock directory lookup when absolute path is provided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 2025-05-17
+
+### Added
+- Tool version and startup time print on first use
+
 ## [1.10.0] - 2025-05-17
 
 ### Added

--- a/dist/server.js
+++ b/dist/server.js
@@ -12,6 +12,8 @@ import packageJson from '../package.json' with { type: 'json' }; // Import packa
 const debugMode = process.env.MCP_CLAUDE_DEBUG === 'true';
 // Track if this is the first tool use for version printing
 let isFirstToolUse = true;
+// Capture server startup time when the module loads
+const serverStartupTime = new Date().toISOString();
 // Dedicated debug logging function
 export function debugLog(message, ...optionalParams) {
     if (debugMode) {
@@ -233,8 +235,7 @@ export class ClaudeCodeServer {
                 debugLog(`[Debug] Attempting to execute Claude CLI with prompt: "${prompt}" in CWD: "${effectiveCwd}"`);
                 // Print tool info on first use
                 if (isFirstToolUse) {
-                    const startupTime = new Date().toISOString();
-                    const versionInfo = `claude_code v${packageJson.version} started at ${startupTime}`;
+                    const versionInfo = `claude_code v${packageJson.version} started at ${serverStartupTime}`;
                     console.error(versionInfo);
                     isFirstToolUse = false;
                 }

--- a/dist/server.js
+++ b/dist/server.js
@@ -10,6 +10,8 @@ import * as path from 'path';
 import packageJson from '../package.json' with { type: 'json' }; // Import package.json with attribute
 // Define debugMode globally using const
 const debugMode = process.env.MCP_CLAUDE_DEBUG === 'true';
+// Track if this is the first tool use for version printing
+let isFirstToolUse = true;
 // Dedicated debug logging function
 export function debugLog(message, ...optionalParams) {
     if (debugMode) {
@@ -229,6 +231,13 @@ export class ClaudeCodeServer {
             }
             try {
                 debugLog(`[Debug] Attempting to execute Claude CLI with prompt: "${prompt}" in CWD: "${effectiveCwd}"`);
+                // Print tool info on first use
+                if (isFirstToolUse) {
+                    const startupTime = new Date().toISOString();
+                    const versionInfo = `claude_code v${packageJson.version} started at ${startupTime}`;
+                    console.error(versionInfo);
+                    isFirstToolUse = false;
+                }
                 const claudeProcessArgs = [this.claudeCliPath, '--dangerously-skip-permissions', '-p', prompt];
                 debugLog(`[Debug] Invoking /bin/bash with args: ${claudeProcessArgs.join(' ')}`);
                 const { stdout, stderr } = await spawnAsync('/bin/bash', // Explicitly use /bin/bash as the command

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/claude-code-mcp",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Simple MCP server for Claude Code one-shot execution",
   "author": "Peter Steinberger",
   "license": "MIT",

--- a/src/__tests__/version-print.test.ts
+++ b/src/__tests__/version-print.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { MCPTestClient } from './utils/mcp-client.js';
+import { getSharedMock } from './utils/persistent-mock.js';
+
+describe('Version Print on First Use', () => {
+  let client: MCPTestClient;
+  let testDir: string;
+  let consoleErrorSpy: any;
+  const serverPath = 'dist/server.js';
+
+  beforeEach(async () => {
+    // Ensure mock exists
+    await getSharedMock();
+    
+    // Create a temporary directory for test files
+    testDir = mkdtempSync(join(tmpdir(), 'claude-code-test-'));
+    
+    // Spy on console.error
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    
+    // Initialize MCP client with custom binary name using absolute path
+    client = new MCPTestClient(serverPath, {
+      CLAUDE_CLI_NAME: '/tmp/claude-code-test-mock/claudeMocked',
+    });
+    
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    // Disconnect client
+    await client.disconnect();
+    
+    // Clean up test directory
+    rmSync(testDir, { recursive: true, force: true });
+    
+    // Restore console.error spy
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should print version and startup time only on first use', async () => {
+    // First tool call
+    await client.callTool('claude_code', {
+      prompt: 'echo "test 1"',
+      workFolder: testDir,
+    });
+    
+    // Find the version print in the console.error calls
+    const findVersionCall = (calls: any[][]) => {
+      return calls.find(call => {
+        const str = call[1] || call[0]; // message might be first or second param
+        return typeof str === 'string' && str.includes('claude_code v') && str.includes('started at');
+      });
+    };
+    
+    // Check that version was printed on first use
+    const versionCall = findVersionCall(consoleErrorSpy.mock.calls);
+    expect(versionCall).toBeDefined();
+    expect(versionCall![1]).toMatch(/claude_code v[0-9]+\.[0-9]+\.[0-9]+ started at \d{4}-\d{2}-\d{2}T/);
+    
+    // Clear the spy but keep the spy active
+    consoleErrorSpy.mockClear();
+    
+    // Second tool call
+    await client.callTool('claude_code', {
+      prompt: 'echo "test 2"',
+      workFolder: testDir,
+    });
+    
+    // Check that version was NOT printed on second use
+    const secondVersionCall = findVersionCall(consoleErrorSpy.mock.calls);
+    expect(secondVersionCall).toBeUndefined();
+    
+    // Third tool call
+    await client.callTool('claude_code', {
+      prompt: 'echo "test 3"',
+      workFolder: testDir,
+    });
+    
+    // Should still not have been called with version print
+    const thirdVersionCall = findVersionCall(consoleErrorSpy.mock.calls);
+    expect(thirdVersionCall).toBeUndefined();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,9 @@ import packageJson from '../package.json' with { type: 'json' }; // Import packa
 // Define debugMode globally using const
 const debugMode = process.env.MCP_CLAUDE_DEBUG === 'true';
 
+// Track if this is the first tool use for version printing
+let isFirstToolUse = true;
+
 // Dedicated debug logging function
 export function debugLog(message?: any, ...optionalParams: any[]): void {
   if (debugMode) {
@@ -273,6 +276,14 @@ export class ClaudeCodeServer {
 
       try {
         debugLog(`[Debug] Attempting to execute Claude CLI with prompt: "${prompt}" in CWD: "${effectiveCwd}"`);
+
+        // Print tool info on first use
+        if (isFirstToolUse) {
+          const startupTime = new Date().toISOString();
+          const versionInfo = `claude_code v${packageJson.version} started at ${startupTime}`;
+          console.error(versionInfo);
+          isFirstToolUse = false;
+        }
 
         const claudeProcessArgs = [this.claudeCliPath, '--dangerously-skip-permissions', '-p', prompt];
         debugLog(`[Debug] Invoking /bin/bash with args: ${claudeProcessArgs.join(' ')}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,9 @@ const debugMode = process.env.MCP_CLAUDE_DEBUG === 'true';
 // Track if this is the first tool use for version printing
 let isFirstToolUse = true;
 
+// Capture server startup time when the module loads
+const serverStartupTime = new Date().toISOString();
+
 // Dedicated debug logging function
 export function debugLog(message?: any, ...optionalParams: any[]): void {
   if (debugMode) {
@@ -279,8 +282,7 @@ export class ClaudeCodeServer {
 
         // Print tool info on first use
         if (isFirstToolUse) {
-          const startupTime = new Date().toISOString();
-          const versionInfo = `claude_code v${packageJson.version} started at ${startupTime}`;
+          const versionInfo = `claude_code v${packageJson.version} started at ${serverStartupTime}`;
           console.error(versionInfo);
           isFirstToolUse = false;
         }


### PR DESCRIPTION
- Tool now prints version and server startup time on first use
- Startup time is captured at server initialization, not on first call
- Simplified changelog format for consistency