### PR TITLE
feat: add session continuity for full context forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ coverage/
 # IDE
 .vscode/
 .idea/
+.osgrep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Added optional `sessionId`, `messages`, and `stateless` arguments so MCP clients can resume Claude Code sessions while preserving legacy one-shot calls by default. Thanks @marcusquinn.
+
 ## [1.10.12] - 2025-05-17
 
 - Fixed MCP server startup issue by ensuring process runs regardless of module detection

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ Executes a prompt directly using the Claude Code CLI with `--dangerously-skip-pe
 
 **Arguments:**
 - `prompt` (string, required): The prompt to send to Claude Code.
-- `options` (object, optional):
-  - `tools` (array of strings, optional): Specific Claude tools to enable (e.g., `Bash`, `Read`, `Write`). Common tools are enabled by default.
+- `workFolder` (string, optional): Absolute working directory for file operations.
+- `sessionId` (string, optional): Parent session ID. Repeated calls with the same ID resume the same Claude Code session.
+- `messages` (array, optional): Conversation history to inject on the first call for a session.
+- `stateless` (boolean, optional): Disable session continuity for this call.
 
 **Example MCP Request:**
 ```json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@steipete/claude-code-mcp",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@steipete/claude-code-mcp",
-      "version": "1.10.11",
+      "version": "1.10.12",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@steipete/claude-code-mcp",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@steipete/claude-code-mcp",
-      "version": "1.10.11",
+      "version": "1.10.12",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.2",
@@ -1182,6 +1182,7 @@
       "version": "22.15.17",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1360,7 +1361,6 @@
     "node_modules/accepts": {
       "version": "1.3.8",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -1397,8 +1397,7 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1420,7 +1419,6 @@
     "node_modules/body-parser": {
       "version": "1.20.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -1542,7 +1540,6 @@
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -1566,8 +1563,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1612,7 +1608,6 @@
     "node_modules/debug": {
       "version": "2.6.9",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1637,7 +1632,6 @@
     "node_modules/destroy": {
       "version": "1.2.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -2235,7 +2229,6 @@
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -2276,7 +2269,6 @@
     "node_modules/fresh": {
       "version": "0.5.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2429,7 +2421,6 @@
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -2619,7 +2610,6 @@
     "node_modules/media-typer": {
       "version": "0.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2627,7 +2617,6 @@
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -2635,7 +2624,6 @@
     "node_modules/methods": {
       "version": "1.1.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2643,7 +2631,6 @@
     "node_modules/mime": {
       "version": "1.6.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -2654,7 +2641,6 @@
     "node_modules/mime-db": {
       "version": "1.52.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2662,7 +2648,6 @@
     "node_modules/mime-types": {
       "version": "2.1.35",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -2698,8 +2683,7 @@
     },
     "node_modules/ms": {
       "version": "2.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2723,7 +2707,6 @@
     "node_modules/negotiator": {
       "version": "0.6.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2802,8 +2785,7 @@
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -2879,7 +2861,6 @@
     "node_modules/qs": {
       "version": "6.13.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -2900,7 +2881,6 @@
     "node_modules/raw-body": {
       "version": "2.5.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -3037,7 +3017,6 @@
     "node_modules/send": {
       "version": "0.19.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -3060,20 +3039,17 @@
     "node_modules/send/node_modules/encodeurl": {
       "version": "1.0.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
@@ -3424,7 +3400,6 @@
     "node_modules/type-is": {
       "version": "1.6.18",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -3460,7 +3435,6 @@
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -3478,6 +3452,7 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3642,6 +3617,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -3849,6 +3825,7 @@
     "node_modules/zod": {
       "version": "3.24.4",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -44,9 +44,9 @@ describe('Claude Code MCP E2E Tests', () => {
       expect(tools[0]).toEqual({
         name: 'claude_code',
         description: expect.stringContaining('Claude Code Agent'),
-        inputSchema: {
+        inputSchema: expect.objectContaining({
           type: 'object',
-          properties: {
+          properties: expect.objectContaining({
             prompt: {
               type: 'string',
               description: 'The detailed natural language prompt for Claude to execute.',
@@ -55,9 +55,18 @@ describe('Claude Code MCP E2E Tests', () => {
               type: 'string',
               description: expect.stringContaining('working directory'),
             },
-          },
+            sessionId: expect.objectContaining({
+              type: 'string',
+            }),
+            messages: expect.objectContaining({
+              type: 'array',
+            }),
+            stateless: expect.objectContaining({
+              type: 'boolean',
+            }),
+          }),
           required: ['prompt'],
-        },
+        }),
       });
     });
   });

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -49,6 +49,9 @@ vi.mock('../../package.json', () => ({
 
 // Get mocked functions
 const mockExistsSync = vi.mocked(existsSync);
+const mockMkdirSync = vi.mocked(mkdirSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
 const mockSpawn = vi.mocked(spawn);
 const mockHomedir = vi.mocked(homedir);
 
@@ -102,6 +105,11 @@ describe('ClaudeCodeServer Unit Tests', () => {
     delete process.env.CLAUDE_CLI_PATH;
     delete process.env.CLAUDE_CLI_NAME;
     delete process.env.MCP_CLAUDE_DEBUG;
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    mockMkdirSync.mockReturnValue(undefined as any);
+    mockWriteFileSync.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -512,6 +520,124 @@ describe('ClaudeCodeServer Unit Tests', () => {
       const result = await promise;
       expect(result.content[0].type).toBe('text');
       expect(result.content[0].text).toBe('tool output');
+    });
+
+    it('should inject first-call context and persist Claude session mapping', async () => {
+      mockHomedir.mockReturnValue('/home/user');
+      mockExistsSync.mockImplementation((value) => {
+        const path = String(value);
+        return path === '/home/user/.claude/local/claude' || path === '/tmp';
+      });
+
+      const module = await import('../server.js');
+      const { ClaudeCodeServer } = module;
+      const server = new ClaudeCodeServer();
+      const mockServerInstance = vi.mocked(Server).mock.results[0].value;
+      const callToolCall = mockServerInstance.setRequestHandler.mock.calls.find(
+        (call: any[]) => call[0].name === 'callTool'
+      );
+      const handler = callToolCall[1];
+      const mockProcess = createMockProcess();
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const promise = handler({
+        params: {
+          name: 'claude_code',
+          arguments: {
+            prompt: '/review the diff',
+            workFolder: '/tmp',
+            sessionId: 'parent-session',
+            messages: [
+              { role: 'user', content: 'Please inspect carefully.' },
+              { role: 'assistant', content: 'I will review the code.' },
+            ],
+          },
+        },
+      });
+
+      setTimeout(() => {
+        mockProcess.stdout['data'](
+          JSON.stringify({
+            type: 'result',
+            result: 'done',
+            session_id: 'claude-session',
+          })
+        );
+        mockProcess.emit('close', 0);
+      }, 10);
+
+      const result = await promise;
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(spawnArgs).toContain('--output-format');
+      expect(spawnArgs).not.toContain('--resume');
+      expect(spawnArgs.at(-1)).toContain('<conversation_context>');
+      expect(spawnArgs.at(-1)).toContain('@review the diff');
+      expect(result.content[0].text).toBe('done');
+      expect(result.content[1].text).toContain('claude-session');
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        '/home/user/.config/claude-code-mcp/sessions.json',
+        expect.stringContaining('claude-session'),
+        { mode: 0o600 }
+      );
+    });
+
+    it('should resume existing Claude sessions by parent sessionId', async () => {
+      mockHomedir.mockReturnValue('/home/user');
+      mockExistsSync.mockImplementation((value) => {
+        const path = String(value);
+        return (
+          path === '/home/user/.claude/local/claude' ||
+          path === '/tmp' ||
+          path === '/home/user/.config/claude-code-mcp/sessions.json'
+        );
+      });
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          'parent-session': {
+            claudeSessionId: 'claude-old',
+            updatedAt: new Date().toISOString(),
+          },
+        }) as any
+      );
+
+      const module = await import('../server.js');
+      const { ClaudeCodeServer } = module;
+      const server = new ClaudeCodeServer();
+      const mockServerInstance = vi.mocked(Server).mock.results[0].value;
+      const callToolCall = mockServerInstance.setRequestHandler.mock.calls.find(
+        (call: any[]) => call[0].name === 'callTool'
+      );
+      const handler = callToolCall[1];
+      const mockProcess = createMockProcess();
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const promise = handler({
+        params: {
+          name: 'claude_code',
+          arguments: {
+            prompt: 'continue',
+            workFolder: '/tmp',
+            sessionId: 'parent-session',
+          },
+        },
+      });
+
+      setTimeout(() => {
+        mockProcess.stdout['data'](
+          JSON.stringify({
+            type: 'result',
+            result: 'continued',
+            session_id: 'claude-new',
+          })
+        );
+        mockProcess.emit('close', 0);
+      }, 10);
+
+      await promise;
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(spawnArgs).toContain('--resume');
+      expect(spawnArgs).toContain('claude-old');
+      expect(spawnArgs.at(-1)).toBe('continue');
     });
 
     it('should handle non-existent workFolder', async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,12 +9,11 @@ import {
   type ServerResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve as pathResolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as path from 'path';
-import { readFileSync } from 'node:fs';
 
 // Server version - update this when releasing new versions
 const SERVER_VERSION = "1.10.12";
@@ -119,6 +118,130 @@ export function findClaudeCli(): string {
 interface ClaudeCodeArgs {
   prompt: string;
   workFolder?: string;
+  sessionId?: string;
+  messages?: ConversationMessage[];
+  stateless?: boolean;
+}
+
+interface ConversationMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ClaudeCliResponse {
+  type: string;
+  result?: string;
+  session_id?: string;
+}
+
+interface SessionEntry {
+  claudeSessionId: string;
+  updatedAt: string;
+}
+
+const MAX_SESSIONS = 1000;
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+const SESSION_FILE =
+  process.env.CLAUDE_CODE_MCP_SESSION_FILE ||
+  join(homedir(), '.config', 'claude-code-mcp', 'sessions.json');
+let sessionMap: Map<string, SessionEntry> | null = null;
+
+function ensureSessionMap(): Map<string, SessionEntry> {
+  if (sessionMap) return sessionMap;
+  sessionMap = new Map();
+  try {
+    if (existsSync(SESSION_FILE)) {
+      const parsed = JSON.parse(readFileSync(SESSION_FILE, 'utf8')) as Record<string, SessionEntry>;
+      sessionMap = new Map(Object.entries(parsed));
+      cleanExpiredSessions();
+    }
+  } catch (error) {
+    debugLog('[Debug] Failed to load Claude session map:', error);
+    sessionMap = new Map();
+  }
+  return sessionMap;
+}
+
+function saveSessionMap(): void {
+  const map = ensureSessionMap();
+  try {
+    mkdirSync(path.dirname(SESSION_FILE), { recursive: true });
+    writeFileSync(SESSION_FILE, JSON.stringify(Object.fromEntries(map), null, 2), {
+      mode: 0o600,
+    });
+  } catch (error) {
+    debugLog('[Debug] Failed to save Claude session map:', error);
+  }
+}
+
+function cleanExpiredSessions(): void {
+  const map = ensureSessionMap();
+  const now = Date.now();
+  let changed = false;
+  for (const [key, entry] of map) {
+    if (now - new Date(entry.updatedAt).getTime() > SESSION_TTL_MS) {
+      map.delete(key);
+      changed = true;
+    }
+  }
+  if (changed) saveSessionMap();
+}
+
+function getSessionMapping(parentSessionId: string): string | undefined {
+  const map = ensureSessionMap();
+  const entry = map.get(parentSessionId);
+  if (!entry) return undefined;
+  if (Date.now() - new Date(entry.updatedAt).getTime() > SESSION_TTL_MS) {
+    map.delete(parentSessionId);
+    saveSessionMap();
+    return undefined;
+  }
+  return entry.claudeSessionId;
+}
+
+function setSessionMapping(parentSessionId: string, claudeSessionId: string): void {
+  const map = ensureSessionMap();
+  if (map.size >= MAX_SESSIONS) {
+    const oldestKey = map.keys().next().value;
+    if (oldestKey) map.delete(oldestKey);
+  }
+  map.set(parentSessionId, {
+    claudeSessionId,
+    updatedAt: new Date().toISOString(),
+  });
+  saveSessionMap();
+}
+
+function formatConversationContext(messages: ConversationMessage[]): string {
+  if (messages.length === 0) return '';
+  const formatted = messages
+    .map((message) => {
+      const role = message.role === 'assistant' ? 'Assistant' : 'User';
+      return `[${role}]: ${message.content}`;
+    })
+    .join('\n\n');
+  return `<conversation_context>\n${formatted}\n</conversation_context>\n\n`;
+}
+
+function translateSlashCommands(prompt: string): string {
+  return prompt.replace(/^\/([a-zA-Z][a-zA-Z0-9_-]*)(?=\s|$)/gm, '@$1');
+}
+
+function parseClaudeResponse(stdout: string): ClaudeCliResponse | null {
+  const trimmed = stdout.trim();
+  const candidates = trimmed.startsWith('{') && trimmed.endsWith('}')
+    ? [trimmed]
+    : trimmed.split('\n').map((line) => line.trim()).filter((line) => line.startsWith('{') && line.endsWith('}')).reverse();
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate) as ClaudeCliResponse;
+      if (parsed.type === 'result') return parsed;
+    } catch {
+      // Try the next JSON-looking line.
+    }
+  }
+  return null;
 }
 
 // Ensure spawnAsync is defined correctly *before* the class
@@ -262,6 +385,32 @@ export class ClaudeCodeServer {
                 type: 'string',
                 description: 'Mandatory when using file operations or referencing any file. The working directory for the Claude CLI execution. Must be an absolute path.',
               },
+              sessionId: {
+                type: 'string',
+                description: 'Parent session ID. When provided, repeated calls resume the same Claude Code session.',
+              },
+              messages: {
+                type: 'array',
+                description: 'Conversation history to inject on the first call for a session.',
+                items: {
+                  type: 'object',
+                  properties: {
+                    role: {
+                      type: 'string',
+                      enum: ['user', 'assistant'],
+                    },
+                    content: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['role', 'content'],
+                },
+              },
+              stateless: {
+                type: 'boolean',
+                description: 'Disable session continuity for this call.',
+                default: false,
+              },
             },
             required: ['prompt'],
           },
@@ -297,6 +446,30 @@ export class ClaudeCodeServer {
         throw new McpError(ErrorCode.InvalidParams, 'Missing or invalid required parameter: prompt (must be an object with a string "prompt" property) for claude_code tool');
       }
 
+      const sessionId = toolArguments.sessionId;
+      if (sessionId !== undefined && typeof sessionId !== 'string') {
+        throw new McpError(ErrorCode.InvalidParams, 'Invalid parameter: sessionId must be a string.');
+      }
+
+      const messages = toolArguments.messages;
+      if (messages !== undefined) {
+        if (!Array.isArray(messages)) {
+          throw new McpError(ErrorCode.InvalidParams, 'Invalid parameter: messages must be an array.');
+        }
+        for (const message of messages) {
+          if (
+            typeof message !== 'object' ||
+            message === null ||
+            (message.role !== 'user' && message.role !== 'assistant') ||
+            typeof message.content !== 'string'
+          ) {
+            throw new McpError(ErrorCode.InvalidParams, 'Invalid parameter: each message must include role and content strings.');
+          }
+        }
+      }
+
+      const stateless = toolArguments.stateless === true;
+
       // Determine the working directory
       let effectiveCwd = homedir(); // Default CWD is user's home directory
 
@@ -326,7 +499,23 @@ export class ClaudeCodeServer {
           isFirstToolUse = false;
         }
 
-        const claudeProcessArgs = ['--dangerously-skip-permissions', '-p', prompt];
+        let processedPrompt = translateSlashCommands(prompt);
+        const claudeProcessArgs = ['--dangerously-skip-permissions'];
+        const useSessionContinuity = !stateless && typeof sessionId === 'string' && sessionId.length > 0;
+
+        if (useSessionContinuity) {
+          const existingClaudeSessionId = getSessionMapping(sessionId);
+          claudeProcessArgs.push('--output-format', 'json');
+          if (existingClaudeSessionId) {
+            claudeProcessArgs.push('--resume', existingClaudeSessionId);
+          } else if (Array.isArray(messages) && messages.length > 0) {
+            processedPrompt = formatConversationContext(messages as ConversationMessage[]) +
+              'Continue the conversation. ' +
+              processedPrompt;
+          }
+        }
+
+        claudeProcessArgs.push('-p', processedPrompt);
         debugLog(`[Debug] Invoking Claude CLI: ${this.claudeCliPath} ${claudeProcessArgs.join(' ')}`);
 
         const { stdout, stderr } = await spawnAsync(
@@ -340,8 +529,27 @@ export class ClaudeCodeServer {
           debugLog('[Debug] Claude CLI stderr:', stderr.trim());
         }
 
-        // Return stdout content, even if there was stderr, as claude-cli might output main result to stdout.
-        return { content: [{ type: 'text', text: stdout }] };
+        if (!useSessionContinuity) {
+          // Return stdout content, even if there was stderr, as claude-cli might output main result to stdout.
+          return { content: [{ type: 'text', text: stdout }] };
+        }
+
+        const parsedResponse = parseClaudeResponse(stdout);
+        if (!parsedResponse) {
+          return { content: [{ type: 'text', text: stdout }] };
+        }
+
+        const resultText = parsedResponse.result ?? '';
+        const claudeSessionId = parsedResponse.session_id;
+        if (claudeSessionId) {
+          setSessionMapping(sessionId, claudeSessionId);
+        }
+
+        const content: { type: 'text'; text: string }[] = [{ type: 'text', text: resultText }];
+        if (claudeSessionId) {
+          content.push({ type: 'text', text: `\n---\n_Session ID: ${claudeSessionId}_` });
+        }
+        return { content };
 
       } catch (error: any) {
         debugLog('[Error] Error executing Claude CLI:', error);

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    fileParallelism: false,
     testTimeout: 30000, // Longer timeout for e2e tests
     hookTimeout: 20000,
     setupFiles: ['./src/__tests__/setup.ts'],


### PR DESCRIPTION
## Summary
- Add session continuity to forward full context across calls
- Add file-based session persistence for reliability across server restarts
- Improve continuity for multi-step Claude Code MCP usage

## Changes
1. **Session continuity** - `sessionId` parameter and `--resume` flag support
2. **File-based persistence** - Sessions stored in `~/.claude-code-mcp/sessions/` survive restarts
3. **Messages injection** - Forward conversation history on first call
4. **Slash command translation** - `/ -> @` for subagent invocation

## Testing
- Manual testing of session persistence across server restarts

## Source
- Fork PR #1: https://github.com/marcusquinn/claude-code-mcp/pull/1
- Fork PR #2: https://github.com/marcusquinn/claude-code-mcp/pull/2